### PR TITLE
additionally allow *.js in specs

### DIFF
--- a/integration/ui-tests/pom.xml
+++ b/integration/ui-tests/pom.xml
@@ -208,7 +208,7 @@
               <configuration>
                 <includeArtifactIds>${galenium.generated.artifactIds}</includeArtifactIds>
                 <outputDirectory>${galenium.generated.specs}</outputDirectory>
-                <includes>**/*.gspec</includes>
+                <includes>**/*.gspec,**/*.js</includes>
                 <excludeTransitive>true</excludeTransitive>
                 <overWriteReleases>true</overWriteReleases>
                 <overWriteSnapshots>true</overWriteSnapshots>


### PR DESCRIPTION
*.js is used for custom javascript functions in specs, but they currently can only be extracted by locally overriding the dependency-plugin configuration
Also, libraries like https://github.com/galenframework/galen-extras can not be extracted.