### PR TITLE
Sort generated "expected" by keys

### DIFF
--- a/modules/core/changes.xml
+++ b/modules/core/changes.xml
@@ -23,6 +23,12 @@
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
 
+    <release version="0.1.21" date="unreleased">
+      <action type="update" dev="rdahlem">
+        Generated expected keys are sorted. Text comparison is in four-digit display to make it better sortable
+      </action>
+    </release>
+    
     <release version="0.1.20" date="2018-12-03">
       <action type="add" dev="apegam">
         Code generation now also generates GaleniumWebElements.

--- a/modules/core/changes.xml
+++ b/modules/core/changes.xml
@@ -25,7 +25,7 @@
 
     <release version="0.1.21" date="unreleased">
       <action type="update" dev="rdahlem">
-        Generated expected keys are sorted. Text comparison is in four-digit display to make it better sortable
+        Generated expected keys are sorted
       </action>
     </release>
     

--- a/modules/core/src/main/java/io/wcm/qa/galenium/persistence/util/TextSampleManager.java
+++ b/modules/core/src/main/java/io/wcm/qa/galenium/persistence/util/TextSampleManager.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.Properties;
 
+import org.apache.commons.collections4.properties.SortedProperties;
 import org.apache.commons.io.output.WriterOutputStream;
 import org.slf4j.Logger;
 
@@ -40,13 +41,13 @@ import io.wcm.qa.galenium.reporting.GaleniumReportUtil;
 public final class TextSampleManager {
 
   private static final Charset CHARSET_UTF8 = Charset.forName("utf-8");
-  private static final Properties EXPECTED_TEXTS = new Properties();
+  private static final SortedProperties EXPECTED_TEXTS = new SortedProperties();
   private static final String FILE_NAME_EXPECTED_TEXTS = GaleniumConfiguration.getTextComparisonFile();
   private static final String FILE_NAME_ROOT_DIR_EXPECTED_TEXTS = GaleniumConfiguration.getTextComparisonInputDirectory();
   private static final String FILE_NAME_ROOT_DIR_SAVE_SAMPLED_TEXTS = GaleniumConfiguration.getTextComparisonOutputDirectory();
   private static final File OUTPUT_FILE = new File(FILE_NAME_ROOT_DIR_SAVE_SAMPLED_TEXTS, FILE_NAME_EXPECTED_TEXTS);
   private static final String PATH_SEPARATOR = "/";
-  private static final Properties SAMPLED_TEXTS = new Properties();
+  private static final SortedProperties SAMPLED_TEXTS = new SortedProperties();
 
   static {
     StringBuilder expectedTextsFilePath = new StringBuilder();

--- a/modules/differences/src/main/java/io/wcm/qa/galenium/differences/difference/ScreenWidthDifference.java
+++ b/modules/differences/src/main/java/io/wcm/qa/galenium/differences/difference/ScreenWidthDifference.java
@@ -36,8 +36,7 @@ public class ScreenWidthDifference extends DifferenceBase {
 
   @Override
   protected String getRawTag() {
-    int width = GaleniumContext.getTestDevice().getScreenSize().getWidth();
-    return String.format("%04d", width);
+    return Integer.toString(GaleniumContext.getTestDevice().getScreenSize().getWidth());
   }
 
 }

--- a/modules/differences/src/main/java/io/wcm/qa/galenium/differences/difference/ScreenWidthDifference.java
+++ b/modules/differences/src/main/java/io/wcm/qa/galenium/differences/difference/ScreenWidthDifference.java
@@ -36,7 +36,8 @@ public class ScreenWidthDifference extends DifferenceBase {
 
   @Override
   protected String getRawTag() {
-    return Integer.toString(GaleniumContext.getTestDevice().getScreenSize().getWidth());
+    int width = GaleniumContext.getTestDevice().getScreenSize().getWidth();
+    return String.format("%04d", width);
   }
 
 }


### PR DESCRIPTION
* sort the expected and sampled tests by key. The changeset will be reduced for most of the cases, when generating expected results
*  key from device width's are prefixed with zeros to make them better sortable