### PR TITLE
init BrowserMopProxy with trusting all certificates

### DIFF
--- a/modules/core/src/main/java/io/wcm/qa/galenium/util/BrowserMobUtil.java
+++ b/modules/core/src/main/java/io/wcm/qa/galenium/util/BrowserMobUtil.java
@@ -120,6 +120,7 @@ public final class BrowserMobUtil {
     if (proxy == null) {
       proxy = new BrowserMobProxyServer();
       proxy.setMitmDisabled(false);
+      proxy.setTrustAllServers(true);
       proxy.start();
       GaleniumContext.put(BROWSER_MOB_PROXY, proxy);
     }


### PR DESCRIPTION
When creating BrowerMobProxy we need to set it to trust all Servers regardless their ssl certificates. 