### PR TITLE
fix: remove method name from log

### DIFF
--- a/integration/resources/src/main/resources/logback.xml
+++ b/integration/resources/src/main/resources/logback.xml
@@ -27,7 +27,7 @@
                <MaxFileSize>5MB</MaxFileSize>
             </triggeringPolicy>
             <layout class="ch.qos.logback.classic.PatternLayout">
-               <Pattern>%d{ISO8601} %-5level %C{1} [%M:%L] [%thread] - %msg%n</Pattern>
+               <Pattern>%d{ISO8601} %-5level %C{1}[%thread] - %msg%n</Pattern>
             </layout>
          </appender>
       </sift>


### PR DESCRIPTION
The configuration is a copy from an example. Method names with line
numbers are too noisy for Galenium logging.