### PR TITLE
chore: organize imports in examples and modules

### DIFF
--- a/examples/tests/src/test/java/io/wcm/qa/glnm/example/VerificationIT.java
+++ b/examples/tests/src/test/java/io/wcm/qa/glnm/example/VerificationIT.java
@@ -27,6 +27,7 @@ import org.testng.annotations.Test;
 import io.wcm.qa.glnm.device.TestDevice;
 import io.wcm.qa.glnm.differences.difference.driver.BrowserDifference;
 import io.wcm.qa.glnm.differences.difference.driver.ScreenWidthDifference;
+import io.wcm.qa.glnm.example.pageobjects.Homepage;
 import io.wcm.qa.glnm.example.selectors.common.Page;
 import io.wcm.qa.glnm.example.selectors.common.Page.Navigation;
 import io.wcm.qa.glnm.example.selectors.homepage.Stage;
@@ -40,7 +41,6 @@ import io.wcm.qa.glnm.verification.element.NoCssClassVerification;
 import io.wcm.qa.glnm.verification.element.VisibilityVerification;
 import io.wcm.qa.glnm.verification.element.VisualVerification;
 import io.wcm.qa.glnm.verification.util.Check;
-import io.wcm.qa.glnm.example.pageobjects.Homepage;
 
 /**
  * Showcase {@link Verification} approach.

--- a/modules/core/src/main/java/io/wcm/qa/glnm/device/TestDevice.java
+++ b/modules/core/src/main/java/io/wcm/qa/glnm/device/TestDevice.java
@@ -22,7 +22,6 @@ package io.wcm.qa.glnm.device;
 import java.util.List;
 
 import org.openqa.selenium.Dimension;
-import org.openqa.selenium.WebDriver;
 
 /**
  * DataModel for browser types, screen sizes and Galen tags. Used to initialize {@link org.openqa.selenium.WebDriver}.

--- a/modules/core/src/main/java/io/wcm/qa/glnm/util/GaleniumContext.java
+++ b/modules/core/src/main/java/io/wcm/qa/glnm/util/GaleniumContext.java
@@ -28,7 +28,6 @@ import org.slf4j.LoggerFactory;
 
 import io.wcm.qa.glnm.configuration.GaleniumConfiguration;
 import io.wcm.qa.glnm.device.TestDevice;
-import io.wcm.qa.glnm.verification.base.Verification;
 import io.wcm.qa.glnm.verification.strategy.DefaultVerificationStrategy;
 import io.wcm.qa.glnm.verification.strategy.IgnoreFailuresStrategy;
 import io.wcm.qa.glnm.verification.strategy.VerificationStrategy;

--- a/modules/core/src/main/java/io/wcm/qa/glnm/verification/strategy/VerificationStrategy.java
+++ b/modules/core/src/main/java/io/wcm/qa/glnm/verification/strategy/VerificationStrategy.java
@@ -19,8 +19,6 @@
  */
 package io.wcm.qa.glnm.verification.strategy;
 
-import org.testng.asserts.Assertion;
-
 import io.wcm.qa.glnm.verification.base.Verification;
 
 /**

--- a/modules/differences/src/main/java/io/wcm/qa/glnm/differences/difference/StringDifference.java
+++ b/modules/differences/src/main/java/io/wcm/qa/glnm/differences/difference/StringDifference.java
@@ -19,7 +19,6 @@
  */
 package io.wcm.qa.glnm.differences.difference;
 
-import io.wcm.qa.glnm.differences.base.Difference;
 import io.wcm.qa.glnm.differences.base.DifferenceBase;
 
 /**

--- a/modules/differences/src/main/java/io/wcm/qa/glnm/differences/difference/driver/BrowserDifference.java
+++ b/modules/differences/src/main/java/io/wcm/qa/glnm/differences/difference/driver/BrowserDifference.java
@@ -19,9 +19,6 @@
  */
 package io.wcm.qa.glnm.differences.difference.driver;
 
-import io.wcm.qa.glnm.device.BrowserType;
-import io.wcm.qa.glnm.device.TestDevice;
-import io.wcm.qa.glnm.differences.base.Difference;
 import io.wcm.qa.glnm.differences.base.DifferenceBase;
 import io.wcm.qa.glnm.util.GaleniumContext;
 

--- a/modules/differences/src/main/java/io/wcm/qa/glnm/differences/difference/driver/ScreenWidthDifference.java
+++ b/modules/differences/src/main/java/io/wcm/qa/glnm/differences/difference/driver/ScreenWidthDifference.java
@@ -19,8 +19,6 @@
  */
 package io.wcm.qa.glnm.differences.difference.driver;
 
-import io.wcm.qa.glnm.device.TestDevice;
-import io.wcm.qa.glnm.differences.base.Difference;
 import io.wcm.qa.glnm.differences.base.DifferenceBase;
 import io.wcm.qa.glnm.util.GaleniumContext;
 

--- a/modules/differences/src/main/java/io/wcm/qa/glnm/differences/util/DifferenceUtil.java
+++ b/modules/differences/src/main/java/io/wcm/qa/glnm/differences/util/DifferenceUtil.java
@@ -25,7 +25,6 @@ import java.util.List;
 import org.apache.commons.lang3.StringUtils;
 
 import io.wcm.qa.glnm.differences.base.Difference;
-import io.wcm.qa.glnm.differences.base.Differences;
 
 /**
  * Helper methods for  {@link io.wcm.qa.glnm.differences.base.Differences} implementations.

--- a/modules/providers/src/main/java/io/wcm/qa/glnm/providers/TestNgProviderUtil.java
+++ b/modules/providers/src/main/java/io/wcm/qa/glnm/providers/TestNgProviderUtil.java
@@ -32,7 +32,6 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.testng.annotations.DataProvider;
 
 import io.wcm.qa.glnm.exceptions.GaleniumException;
 import io.wcm.qa.glnm.sampling.Sampler;

--- a/modules/sampling/src/main/java/io/wcm/qa/glnm/sampling/element/base/SelectorBasedSampler.java
+++ b/modules/sampling/src/main/java/io/wcm/qa/glnm/sampling/element/base/SelectorBasedSampler.java
@@ -19,8 +19,8 @@
  */
 package io.wcm.qa.glnm.sampling.element.base;
 
-import io.wcm.qa.glnm.selectors.base.Selector;
 import io.wcm.qa.glnm.sampling.base.CachingBasedSampler;
+import io.wcm.qa.glnm.selectors.base.Selector;
 
 /**
  * Selector based sampling.

--- a/modules/sampling/src/main/java/io/wcm/qa/glnm/sampling/htmlcleaner/HtmlCleanerSampler.java
+++ b/modules/sampling/src/main/java/io/wcm/qa/glnm/sampling/htmlcleaner/HtmlCleanerSampler.java
@@ -28,7 +28,6 @@ import org.htmlcleaner.HtmlSerializer;
 import org.htmlcleaner.SimpleHtmlSerializer;
 import org.htmlcleaner.TagNode;
 import org.htmlcleaner.TagNodeVisitor;
-import org.jsoup.Jsoup;
 import org.jsoup.nodes.Element;
 
 import io.wcm.qa.glnm.sampling.htmlcleaner.visitors.CssClassSorter;

--- a/modules/sampling/src/main/java/io/wcm/qa/glnm/sampling/jsoup/JsoupDocumentSampler.java
+++ b/modules/sampling/src/main/java/io/wcm/qa/glnm/sampling/jsoup/JsoupDocumentSampler.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 
 import org.jsoup.Connection;
 import org.jsoup.HttpStatusException;
-import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/modules/selectors/src/main/java/io/wcm/qa/glnm/selectors/SelectorFromLocator.java
+++ b/modules/selectors/src/main/java/io/wcm/qa/glnm/selectors/SelectorFromLocator.java
@@ -22,7 +22,6 @@ package io.wcm.qa.glnm.selectors;
 import com.galenframework.specs.page.Locator;
 
 import io.wcm.qa.glnm.selectors.base.AbstractNestedSelectorBase;
-import io.wcm.qa.glnm.selectors.base.Selector;
 
 /**
  * Turns a Galen {@link com.galenframework.specs.page.Locator} object into a Galenium  {@link io.wcm.qa.glnm.selectors.base.Selector}.

--- a/modules/selectors/src/main/java/io/wcm/qa/glnm/selectors/SelectorFromString.java
+++ b/modules/selectors/src/main/java/io/wcm/qa/glnm/selectors/SelectorFromString.java
@@ -20,7 +20,6 @@
 package io.wcm.qa.glnm.selectors;
 
 import io.wcm.qa.glnm.selectors.base.AbstractSelectorBase;
-import io.wcm.qa.glnm.selectors.base.Selector;
 
 /**
  * Implementation of  {@link io.wcm.qa.glnm.selectors.base.Selector} interface.

--- a/modules/verification/src/main/java/io/wcm/qa/glnm/verification/diff/StringDiffVerification.java
+++ b/modules/verification/src/main/java/io/wcm/qa/glnm/verification/diff/StringDiffVerification.java
@@ -21,8 +21,6 @@ package io.wcm.qa.glnm.verification.diff;
 
 import java.util.List;
 
-import org.apache.commons.lang3.StringUtils;
-
 import io.wcm.qa.glnm.persistence.util.TextSampleManager;
 import io.wcm.qa.glnm.sampling.Sampler;
 import io.wcm.qa.glnm.sampling.transform.StringToListSampler;

--- a/modules/verification/src/main/java/io/wcm/qa/glnm/verification/util/Check.java
+++ b/modules/verification/src/main/java/io/wcm/qa/glnm/verification/util/Check.java
@@ -21,9 +21,7 @@ package io.wcm.qa.glnm.verification.util;
 
 import static io.wcm.qa.glnm.util.GaleniumContext.getVerificationStrategy;
 
-import io.wcm.qa.glnm.util.GaleniumContext;
 import io.wcm.qa.glnm.verification.base.Verification;
-import io.wcm.qa.glnm.verification.strategy.VerificationStrategy;
 
 /**
  * Handles verification using the strategy from  {@link io.wcm.qa.glnm.util.GaleniumContext#getVerificationStrategy()}.


### PR DESCRIPTION
This should get rid of some of the new warnings on CI. The imports
were introduced because of links in Javadoc comments. All the links
were fully qualified by the recent javadoc:fix run, so the imports
are obsolete now.