### PR TITLE
feat: add transforming sampler interface and default constructors

### DIFF
--- a/modules/sampling/src/main/java/io/wcm/qa/glnm/sampling/TransformingSampler.java
+++ b/modules/sampling/src/main/java/io/wcm/qa/glnm/sampling/TransformingSampler.java
@@ -19,19 +19,21 @@
  */
 package io.wcm.qa.glnm.sampling;
 
-import io.wcm.qa.glnm.exceptions.GaleniumException;
-
 /**
- * Unusable sampler which throws an exception when sampled. Awkward workaround to avoid passing a null sampler.
+ * Generates sample based on sample from input sampler.
  *
- * @param <T> type never to sample
- * @since 3.0.0
+ * @param <IS> input sampler to get input from
+ * @param <I> type of input
+ * @param <O> type of output
+ * @since 4.0.0
  */
-public final class UselessSampler<T> implements Sampler<T> {
+public interface TransformingSampler<IS extends Sampler<I>, I, O> extends Sampler<O> {
 
-  /** {@inheritDoc} */
-  @Override
-  public T sampleValue() {
-    throw new GaleniumException("This sampler should never be used to sample.");
-  }
+  /**
+   * <p>getInput.</p>
+   *
+   * @return the input sampler
+   */
+  IS getInput();
+
 }

--- a/modules/sampling/src/main/java/io/wcm/qa/glnm/sampling/aem/JcrQuerySampler.java
+++ b/modules/sampling/src/main/java/io/wcm/qa/glnm/sampling/aem/JcrQuerySampler.java
@@ -38,7 +38,6 @@ import com.google.common.collect.Maps;
 
 import io.wcm.qa.glnm.exceptions.GaleniumException;
 import io.wcm.qa.glnm.sampling.Sampler;
-import io.wcm.qa.glnm.sampling.UselessSampler;
 import io.wcm.qa.glnm.sampling.jsoup.JsoupRawStringSampler;
 import io.wcm.qa.glnm.sampling.transform.JsonSampler;
 
@@ -77,9 +76,8 @@ public class JcrQuerySampler extends JsonSampler<Sampler<String>> {
   /**
    * Constructor.
    */
-  @SuppressWarnings("unchecked")
   public JcrQuerySampler() {
-    super(new UselessSampler());
+    super();
   }
 
   /**

--- a/modules/sampling/src/main/java/io/wcm/qa/glnm/sampling/transform/JsonSampler.java
+++ b/modules/sampling/src/main/java/io/wcm/qa/glnm/sampling/transform/JsonSampler.java
@@ -53,6 +53,15 @@ public class JsonSampler<S extends Sampler<String>> extends TransformationBasedS
     super(inputSampler);
   }
 
+  /**
+   * <p>
+   * Constructor for JsonSampler which requires using setter to provide input sampler.
+   * </p>
+   */
+  public JsonSampler() {
+    super();
+  }
+
   private String asString(Entry<String, Object> entry) {
     Object value = entry.getValue();
     if (value == null) {

--- a/modules/sampling/src/main/java/io/wcm/qa/glnm/sampling/transform/base/TransformationBasedSampler.java
+++ b/modules/sampling/src/main/java/io/wcm/qa/glnm/sampling/transform/base/TransformationBasedSampler.java
@@ -21,6 +21,7 @@ package io.wcm.qa.glnm.sampling.transform.base;
 
 import io.wcm.qa.glnm.sampling.CanCache;
 import io.wcm.qa.glnm.sampling.Sampler;
+import io.wcm.qa.glnm.sampling.TransformingSampler;
 import io.wcm.qa.glnm.sampling.base.CachingBasedSampler;
 
 /**
@@ -31,7 +32,7 @@ import io.wcm.qa.glnm.sampling.base.CachingBasedSampler;
  * @param <O> type of transformed output
  * @since 1.0.0
  */
-public abstract class TransformationBasedSampler<S extends Sampler<I>, I, O> extends CachingBasedSampler<O> {
+public abstract class TransformationBasedSampler<S extends Sampler<I>, I, O> extends CachingBasedSampler<O> implements TransformingSampler<S, I, O> {
 
   private S input;
 
@@ -42,7 +43,16 @@ public abstract class TransformationBasedSampler<S extends Sampler<I>, I, O> ext
    * @since 3.0.0
    */
   public TransformationBasedSampler(S inputSampler) {
+    this();
     setInput(inputSampler);
+  }
+
+  /**
+   * Transformation based samplers need an input sampler to operate. Using this
+   * constructor requires input to be configured via setter before sampling.
+   */
+  public TransformationBasedSampler() {
+    super();
   }
 
   /** {@inheritDoc} */
@@ -71,7 +81,9 @@ public abstract class TransformationBasedSampler<S extends Sampler<I>, I, O> ext
     }
   }
 
-  protected S getInput() {
+  /** {@inheritDoc} */
+  @Override
+  public S getInput() {
     return input;
   }
 


### PR DESCRIPTION
Access to input samplers is important when implementing project
specific functionality. Setting input samplers is more convenient than
overwriting whole chains of transformation based samplers.