### PR TITLE
fix: add interface declaration directly

### DIFF
--- a/modules/icing/src/main/java/io/wcm/qa/glnm/junit/seljup/BrowserTypesProvider.java
+++ b/modules/icing/src/main/java/io/wcm/qa/glnm/junit/seljup/BrowserTypesProvider.java
@@ -21,7 +21,10 @@ package io.wcm.qa.glnm.junit.seljup;
 
 import java.util.function.Function;
 
+import org.junit.jupiter.params.support.AnnotationConsumer;
+
 import io.github.bonigarcia.seljup.BrowserType;
+import io.wcm.qa.glnm.junit.combinatorial.CombinableProvider;
 
 /**
  * Provides browser types for combinatorial tests.
@@ -32,7 +35,10 @@ public class BrowserTypesProvider
     extends AbstractConsumingCombinableProvider<
         BrowserType,
         BrowserTypes,
-        BrowserInjectionExtension> {
+        BrowserInjectionExtension>
+    implements
+    CombinableProvider,
+    AnnotationConsumer<BrowserTypes> {
 
   @Override
   protected Function<BrowserType, BrowserInjectionExtension> extensionProducer() {

--- a/modules/icing/src/main/java/io/wcm/qa/glnm/junit/seljup/ViewportWidthProvider.java
+++ b/modules/icing/src/main/java/io/wcm/qa/glnm/junit/seljup/ViewportWidthProvider.java
@@ -24,11 +24,18 @@ import static java.util.Arrays.stream;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import org.junit.jupiter.params.support.AnnotationConsumer;
+
+import io.wcm.qa.glnm.junit.combinatorial.CombinableProvider;
+
 class ViewportWidthProvider
     extends AbstractConsumingCombinableProvider<
         Integer,
         ViewportWidths,
-        ViewportWidthExtension> {
+        ViewportWidthExtension>
+    implements
+    CombinableProvider,
+    AnnotationConsumer<ViewportWidths> {
 
   @Override
   protected Function<Integer, ViewportWidthExtension> extensionProducer() {


### PR DESCRIPTION
AnnotationConsumer gathering only looks at directly implemented interfaces.
Future improvement could be to check super classes and meta annotations.