### PR TITLE
fix(hamcrest): add caching to avoid multiple mapping actions

### DIFF
--- a/modules/icing/src/main/java/io/wcm/qa/glnm/hamcrest/TypeSafeWrappingMatcher.java
+++ b/modules/icing/src/main/java/io/wcm/qa/glnm/hamcrest/TypeSafeWrappingMatcher.java
@@ -80,6 +80,7 @@ public abstract class TypeSafeWrappingMatcher<T, M> extends TypeSafeMatcher<T> {
 
   @Override
   protected boolean matchesSafely(T item) {
+    mappedItems.refresh(item);
     return getInternalMatcher().matches(mapped(item));
   }
 


### PR DESCRIPTION
Matchers were re-executing the mapping for description. Inefficient and
error prone. Sometimes result was different on second execution.