### PR TITLE
fix: remove redundant version, extent reports reference

### DIFF
--- a/integration/specs/pom.xml
+++ b/integration/specs/pom.xml
@@ -63,7 +63,6 @@
     <dependency>
       <groupId>com.galenframework</groupId>
       <artifactId>galen-java-support</artifactId>
-      <version>2.4.4</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.commons</groupId>
@@ -113,28 +112,6 @@
 
   <build>
     <plugins>
-
-      <!-- Do not initialize ExtentReport when generating specs -->
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>properties-maven-plugin</artifactId>
-        <version>1.0.0</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>set-system-properties</goal>
-            </goals>
-            <configuration>
-              <properties>
-                <property>
-                  <name>galenium.report.extent.skip</name>
-                  <value>true</value>
-                </property>
-              </properties>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
 
       <plugin>
         <groupId>net.revelc.code.formatter</groupId>


### PR DESCRIPTION
Extent Reports was replaced by Allure Reports. Version is declared in
dependency management.