### PR TITLE
fix: make aspect singleton

### DIFF
--- a/modules/core/src/main/aspect/io/wcm/qa/glnm/aspectj/AssertAspect.java
+++ b/modules/core/src/main/aspect/io/wcm/qa/glnm/aspectj/AssertAspect.java
@@ -39,7 +39,7 @@ import io.wcm.qa.glnm.reporting.GaleniumReportUtil;
  *
  * @since 5.0.0
  */
-@Aspect("percflow(call(public static void org.hamcrest.MatcherAssert.assertThat(String, Object, org.hamcrest.Matcher)))")
+@Aspect
 public class AssertAspect {
 
   private static final Logger LOG = LoggerFactory.getLogger(AssertAspect.class);


### PR DESCRIPTION
Since member variable is gone, there is no state and no
need for multiple instances.