### PR TITLE
fix: remove spec unpacking step

### DIFF
--- a/integration/specs/pom.xml
+++ b/integration/specs/pom.xml
@@ -141,19 +141,6 @@
           <artifactId>maven-dependency-plugin</artifactId>
           <executions>
             <execution>
-              <id>unpack-specs</id>
-              <goals>
-                <goal>unpack-dependencies</goal>
-              </goals>
-              <phase>generate-resources</phase>
-              <configuration>
-                <includeArtifactIds>${galenium.generated.artifactIds}</includeArtifactIds>
-                <outputDirectory>${galenium.generated.specs}</outputDirectory>
-                <includes>**/*.gspec</includes>
-                <excludeTransitive>true</excludeTransitive>
-              </configuration>
-            </execution>
-            <execution>
               <id>unpack-freemarker-resources</id>
               <goals>
                 <goal>unpack-dependencies</goal>

--- a/integration/ui-tests/pom.xml
+++ b/integration/ui-tests/pom.xml
@@ -384,21 +384,6 @@
           <artifactId>maven-dependency-plugin</artifactId>
           <executions>
             <execution>
-              <id>unpack-specs</id>
-              <goals>
-                <goal>unpack-dependencies</goal>
-              </goals>
-              <phase>generate-resources</phase>
-              <configuration>
-                <includeArtifactIds>${galenium.generated.artifactIds}</includeArtifactIds>
-                <outputDirectory>${galenium.generated.specs}</outputDirectory>
-                <includes>**/*.gspec,**/*.js</includes>
-                <excludeTransitive>true</excludeTransitive>
-                <overWriteReleases>true</overWriteReleases>
-                <overWriteSnapshots>true</overWriteSnapshots>
-              </configuration>
-            </execution>
-            <execution>
               <id>unpack-ui-test-resources</id>
               <goals>
                 <goal>unpack-dependencies</goal>


### PR DESCRIPTION
Specs can just be used as resources directly from the dependencies.